### PR TITLE
Update PATTERNS_PATH, resolves issue #8

### DIFF
--- a/git_vuln_finder/pattern.py
+++ b/git_vuln_finder/pattern.py
@@ -22,7 +22,7 @@ def tree():
     return defaultdict(tree)
 
 
-PATTERNS_PATH = "./git_vuln_finder/patterns"
+PATTERNS_PATH = os.path.dirname(os.path.abspath(__file__)) + "/patterns"
 
 
 def build_pattern(pattern_file):


### PR DESCRIPTION
As mentioned by @SecurityRepo in issue cve-search#8, the tool would not return any potential vulnerabilities when used as a command-line tool. When using git-vuln-finder as a library, I received the error message:

```
File ".../venv/lib/python3.8/site-packages/git_vuln_finder/vulnerability.py", line 21, in find_vuln
    m = pattern.search(commit.message)
AttributeError: 'collections.defaultdict' object has no attribute 'search'
```

The issue is when loading the patterns, the PATTERNS_PATH was hard-coded to "./git_vuln_finder/patterns" and this path changes when installed; therefore, it would not load any patterns to search against. The path needs to be loaded dynamically: os.path.dirname(os.path.abspath(_ file _)) + "/patterns"

Once I made the change, git-vuln-finder started to return results. I have opened a pull request to resolve issue cve-search#8.

Thanks!